### PR TITLE
Instapaper no longer has "starred" items

### DIFF
--- a/instapaper_to_pdf.rb
+++ b/instapaper_to_pdf.rb
@@ -45,9 +45,6 @@ page = agent.submit form
 # Follow the redirect.
 page = page.link_with(:text => "Click here if you aren't redirected").click
 
-# Go to the page for starred items.
-page = page.link_with(:text => "Starred").click
-
 # Print a PDF of each article.
 page.links_with(:text => "Text").each do |link|
   article_page = link.click


### PR DESCRIPTION
Instapaper no longer has the concept of "Starred" items so, the script breaks when it tries to "click" that link.
